### PR TITLE
Trimming searched items and can show/hide own subjects in results

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -174,60 +174,27 @@ const App = () => {
     setAlertText("");
   };
 
-  return (
-    <ThemeProvider theme={defaultTheme}>
+  return <ThemeProvider theme={defaultTheme}>
       <Box display="flex" minHeight="100vh">
         <CssBaseline />
         <Box sx={{ flex: 1, display: "flex", flexDirection: "column" }}>
           <Box component="main" sx={{ flex: 1 }} p={{ xs: 1, sm: 2, md: 4 }}>
-            <Grid
-              container
-              direction="column"
-              spacing={2}
-              justify="center"
-              alignContent="center"
-            >
+            <Grid container direction="column" spacing={2} justify="center" alignContent="center">
               <Grid item xs={12} sm={6} md={4} lg={3}>
-                <Paper
-                  sx={{
-                    p: 2,
-                    maxWidth: 1000,
-                    margin: "auto",
-                    overflow: "hidden",
-                  }}
-                >
-                  <Search
-                    onDataFetch={handleDataFetch}
-                    onLoadingStart={handleLoadingStart}
-                    isLoading={loading}
-                  />
+                <Paper sx={{ p: 2, maxWidth: 1000, margin: "auto", overflow: "hidden" }}>
+                  <Search onDataFetch={handleDataFetch} onLoadingStart={handleLoadingStart} isLoading={loading} />
                 </Paper>
               </Grid>
-              {firstSearchDone && (
-                <Grid item xs={12}>
+              {firstSearchDone && <Grid item xs={12}>
                   <Paper sx={{ p: 2 }}>
-                    <Results
-                      tableData={searchResults}
-                      onLessonSave={handleLessonSave}
-                      savedLessons={savedLessons}
-                      isLoading={loading}
-                      own={false}
-                    />
+                    <Results tableData={searchResults} onLessonSave={handleLessonSave} savedLessons={savedLessons} isLoading={loading} own={false} />
                   </Paper>
-                </Grid>
-              )}
-              {firstSearchDone && (
-                <Grid item xs={12}>
+                </Grid>}
+              {firstSearchDone && <Grid item xs={12}>
                   <Paper sx={{ p: 2 }}>
-                    <Calendar
-                      tableData={convertDataToCalendar(searchResults)}
-                      onCalendarClick={handleCalendarClick}
-                      savedLessons={savedLessons}
-                      own={false}
-                    />
+                    <Calendar tableData={convertDataToCalendar(searchResults)} onCalendarClick={handleCalendarClick} savedLessons={savedLessons} own={false} />
                   </Paper>
-                </Grid>
-              )}
+                </Grid>}
               <Grid item xs={12}>
                 <Typography variant="h5" component="h2">
                   Saját órarendem
@@ -237,42 +204,18 @@ const App = () => {
               </Grid>
               <Grid item xs={12}>
                 <Paper sx={{ p: 2 }}>
-                  <Results
-                    tableData={savedLessons}
-                    onLessonSave={handleLessonSave}
-                    savedLessons={savedLessons}
-                    isLoading={loading}
-                    onEventEdit={setEditEvent}
-                    onEventChange={handleEventChange}
-                    own={true}
-                  />
+                  <Results tableData={savedLessons} onLessonSave={handleLessonSave} savedLessons={savedLessons} isLoading={loading} onEventEdit={setEditEvent} onEventChange={handleEventChange} own={true} />
                 </Paper>
               </Grid>
-              {savedLessons.length > 0 && (
-                <Grid item xs={12}>
+              {savedLessons.length > 0 && <Grid item xs={12}>
                   <Paper sx={{ p: 2 }}>
-                    <Calendar
-                      tableData={convertDataToCalendar(savedLessons)}
-                      onCalendarClick={handleCalendarClick}
-                      onImageDownload={handleDownloadImage}
-                      savedLessons={savedLessons}
-                      onEventEdit={setEditEvent}
-                      own={true}
-                    />
+                    <Calendar tableData={convertDataToCalendar(savedLessons)} onCalendarClick={handleCalendarClick} onImageDownload={handleDownloadImage} savedLessons={savedLessons} onEventEdit={setEditEvent} own={true} />
                   </Paper>
-                </Grid>
-              )}
+                </Grid>}
             </Grid>
           </Box>
 
-          {!!editEvent && (
-            <EditEvent
-              eventId={editEvent}
-              savedLessons={savedLessons}
-              onEventChange={handleEventChange}
-              onEventEdit={setEditEvent}
-            />
-          )}
+          {!!editEvent && <EditEvent eventId={editEvent} savedLessons={savedLessons} onEventChange={handleEventChange} onEventEdit={setEditEvent} />}
 
           <Box component="footer" sx={{ p: 2 }}>
             <Copyright />
@@ -281,8 +224,7 @@ const App = () => {
       </Box>
 
       {!!alertText && <Alert alertText={alertText} handleClose={handleClose} />}
-    </ThemeProvider>
-  );
+    </ThemeProvider>;
 };
 
 export default App;

--- a/src/Calendar.jsx
+++ b/src/Calendar.jsx
@@ -15,6 +15,8 @@ import EventBusyIcon from "@mui/icons-material/EventBusy";
 import DownloadIcon from "@mui/icons-material/Download";
 import AddIcon from "@mui/icons-material/Add";
 import momentTimezonePlugin from "@fullcalendar/moment-timezone";
+import { Visibility, VisibilityOff } from "@mui/icons-material";
+import { convertDataToCalendar } from "./utils/Data";
 
 const Calendar = ({
   tableData,
@@ -29,6 +31,9 @@ const Calendar = ({
     anchorEl: null,
     event: null,
   });
+
+  const [showOwnSubjects, setShowOwnSubjects] = useState(false);
+  const [data, setData] = useState(tableData);
 
   const handlePopoverOpen = (event, eventInfo) => {
     setPopoverInfo({ anchorEl: event.currentTarget, event: eventInfo });
@@ -53,6 +58,15 @@ const Calendar = ({
     }
   }, [stickyHeader, onImageDownload]);
 
+  useEffect(() => {
+    if (showOwnSubjects) {
+      setData([...tableData, ...convertDataToCalendar(savedLessons)]);
+    }
+    else {
+      setData(tableData);
+    }
+  }, [tableData, showOwnSubjects, savedLessons]);
+
   // egyéb
   const isPopoverOpen = Boolean(popoverInfo.anchorEl);
 
@@ -69,6 +83,7 @@ const Calendar = ({
   const isEventInSaved = (eventId) => {
     return savedLessons.some((lesson) => lesson.id === parseInt(eventId));
   };
+
 
   return (
     <>
@@ -105,13 +120,31 @@ const Calendar = ({
         </Stack>
       )}
 
+      {
+        !own && (
+          <Stack
+          direction={{ xs: "column", sm: "row" }}
+          spacing={2}
+          marginBottom={2}
+        >
+          <Button
+            variant="outlined"
+            startIcon={showOwnSubjects ? <Visibility /> : <VisibilityOff />}
+            onClick={() => setShowOwnSubjects(!showOwnSubjects)}
+          >
+            Saját tárgyak mutatása
+          </Button>
+        </Stack>
+        )
+      }
+
       <div ref={printRef}>
         <FullCalendar
           plugins={[timeGridPlugin, momentTimezonePlugin]}
           initialView="timeGridWeek"
           weekends={false}
           stickyHeaderDates={stickyHeader}
-          events={tableData}
+          events={data}
           headerToolbar={false}
           allDaySlot={false}
           slotMinTime="08:00:00"
@@ -136,6 +169,10 @@ const Calendar = ({
                 }`}
                 onMouseEnter={(e) => handlePopoverOpen(e, eventInfo)}
                 onMouseLeave={handlePopoverClose}
+                style={{
+                  opacity: isEventInSaved(eventInfo.event.id) && !own ? 0.6 : 1,
+                  backgroundColor: isEventInSaved(eventInfo.event.id) && !own ? "gray" : "",
+                }}
               >
                 <div className="fc-event-time">
                   <b>{eventInfo.timeText}</b>

--- a/src/Calendar.jsx
+++ b/src/Calendar.jsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect, useMemo } from "react";
 import PropTypes from "prop-types";
 import FullCalendar from "@fullcalendar/react";
 import timeGridPlugin from "@fullcalendar/timegrid";
@@ -33,7 +33,14 @@ const Calendar = ({
   });
 
   const [showOwnSubjects, setShowOwnSubjects] = useState(false);
-  const [data, setData] = useState(tableData);
+  const data = useMemo(() => {
+    if (showOwnSubjects) {
+      return [...tableData, ...convertDataToCalendar(savedLessons)];
+    }
+    else {
+      return tableData;
+    }
+  }, [tableData, showOwnSubjects, savedLessons]);
 
   const handlePopoverOpen = (event, eventInfo) => {
     setPopoverInfo({ anchorEl: event.currentTarget, event: eventInfo });
@@ -58,15 +65,7 @@ const Calendar = ({
     }
   }, [stickyHeader, onImageDownload]);
 
-  useEffect(() => {
-    if (showOwnSubjects) {
-      setData([...tableData, ...convertDataToCalendar(savedLessons)]);
-    }
-    else {
-      setData(tableData);
-    }
-  }, [tableData, showOwnSubjects, savedLessons]);
-
+  
   // egyéb
   const isPopoverOpen = Boolean(popoverInfo.anchorEl);
 
@@ -129,10 +128,10 @@ const Calendar = ({
         >
           <Button
             variant="outlined"
-            startIcon={showOwnSubjects ? <Visibility /> : <VisibilityOff />}
+            startIcon={showOwnSubjects ? <VisibilityOff /> : <Visibility />}
             onClick={() => setShowOwnSubjects(!showOwnSubjects)}
           >
-            Saját tárgyak mutatása
+            {showOwnSubjects ? "Saját tárgyak elrejtése" : "Saját tárgyak mutatása"}
           </Button>
         </Stack>
         )

--- a/src/Search.jsx
+++ b/src/Search.jsx
@@ -56,8 +56,12 @@ const Search = ({ onLoadingStart, onDataFetch, isLoading }) => {
     event.preventDefault();
 
     const data = new FormData(event.currentTarget);
+
+    const name = data.get("name").trim();
+    
+    
     const formData = {
-      name: data.get("name"),
+      name: name,
       year: year,
       mode: mode,
     };


### PR DESCRIPTION
When searching for course codes or names, the program removes all spaces from before and after the searched string. Implemented code in the results Calendar, that can show and hide your own subjects in it, so that you can see where you have collisions in the results and which ones can you add to your own calendar