### PR TITLE
Added undo redo functionality and removed new badge

### DIFF
--- a/src/calendars/LessonCalendar.tsx
+++ b/src/calendars/LessonCalendar.tsx
@@ -90,7 +90,7 @@ const LessonCalendar: React.FC<LessonCalendarProps> = ({
 
     return (
         <>
-            <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} marginBottom={2}>
+            <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} marginBottom={2} useFlexGap>
                 {onImageDownload && (
                     <Button variant="outlined" startIcon={<DownloadIcon />} onClick={handlePrintClick}>
                         Mentés képként

--- a/src/calendars/OwnCalendar.tsx
+++ b/src/calendars/OwnCalendar.tsx
@@ -4,15 +4,20 @@ import { EventClickArg } from '@fullcalendar/core';
 import AddIcon from '@mui/icons-material/Add';
 import EditCalendarIcon from '@mui/icons-material/EditCalendar';
 import LinkIcon from '@mui/icons-material/Link';
-import { Badge, Button } from '@mui/material';
+import { Badge, Box, Button, IconButton, Stack } from '@mui/material';
 import type { Lesson } from '../utils/data';
 import LessonCalendar from './LessonCalendar';
+import { Redo, Undo } from '@mui/icons-material';
 
 type OwnCalendarProps = {
     lessons: Lesson[]; // A megjelenítendő órák
     onUrlExport: () => void; // URL export kezelő
     onImageDownload: (ref: React.MutableRefObject<HTMLElement>) => Promise<void>; // Kép mentés kezelő
     onEventEdit: (id: number) => void; // Óra szerkesztés kezelő
+    canUndo: boolean;
+    canRedo: boolean;
+    undo: () => void;
+    redo: () => void;
 };
 
 const OwnCalendar: React.FC<OwnCalendarProps> = ({
@@ -20,6 +25,10 @@ const OwnCalendar: React.FC<OwnCalendarProps> = ({
     onUrlExport,
     onImageDownload,
     onEventEdit,
+    canUndo,
+    canRedo,
+    undo,
+    redo
 }: OwnCalendarProps) => {
     const onEventClick = (eventInfo: EventClickArg) => onEventEdit(parseInt(eventInfo.event.id));
 
@@ -44,11 +53,11 @@ const OwnCalendar: React.FC<OwnCalendarProps> = ({
             popoverActionIcon={() => <EditCalendarIcon fontSize="small" />}
             popoverActionText={() => 'Kattints a szerkesztéshez'}
         >
-            <Badge badgeContent="ÚJ" color="secondary">
-                <Button variant="outlined" startIcon={<LinkIcon />} onClick={onUrlExport} fullWidth>
-                    Mentés hivatkozásként
-                </Button>
-            </Badge>
+            
+            <Button variant="outlined" startIcon={<LinkIcon />} onClick={onUrlExport} >
+                Mentés hivatkozásként
+            </Button>
+            
 
             <Button
                 variant="outlined"
@@ -59,6 +68,33 @@ const OwnCalendar: React.FC<OwnCalendarProps> = ({
             >
                 Saját kurzus hozzáadása
             </Button>
+
+
+  
+            <Stack
+                direction="row"
+                marginLeft="auto"
+            >
+                <IconButton
+                    aria-label='Visszavonás'
+                    color="success"
+                    onClick={undo}
+                    disabled={!canUndo}
+                    sx={{marginRight: "auto"}}
+                >
+                    <Undo/>
+                </IconButton>
+
+                <IconButton
+                    aria-label="Újra csinálás"
+                    color="success"
+                    onClick={redo}
+                    disabled={!canRedo}
+                >
+                    <Redo/>
+                </IconButton>
+            </Stack>
+            
         </LessonCalendar>
     );
 };

--- a/src/calendars/ViewOnlyCalendar.tsx
+++ b/src/calendars/ViewOnlyCalendar.tsx
@@ -47,11 +47,11 @@ const ViewOnlyCalendar: React.FC<ViewOnlyCalendarProps> = ({
                 );
             }}
         >
-            <Badge badgeContent="ÚJ" color="secondary">
-                <Button variant="outlined" startIcon={<LinkIcon />} onClick={onUrlExport} fullWidth>
-                    Mentés hivatkozásként
-                </Button>
-            </Badge>
+            
+            <Button variant="outlined" startIcon={<LinkIcon />} onClick={onUrlExport}>
+                Mentés hivatkozásként
+            </Button>
+          
 
             <Button
                 variant="outlined"


### PR DESCRIPTION
## Changes

- **Undo/Redo Functionality**: 
  Added basic undo/redo functionality for `savedLessons`. Users can now undo any mutation to `savedLessons` by pressing the undo button or using the keyboard shortcut `Ctrl+Z`. Similarly, redo functionality is available with the redo button or `Ctrl+Y`.
  
- **Removed "New" Badge**: 
  The "New" badge has been removed from the link-saving button as it is no longer relevant.

## Limitations

- **History Cap**: A maximum of 30 actions can be undone.
- **No Local Persistence**: The undo/redo history is not stored locally, so it will reset if the page is reloaded.
- **Action Granularity**: Actions such as hiding and unhiding a lesson are treated as separate undoable actions.
- **Toasts on Undo/Redo**: Toasts do not appear when undoing or redoing actions. Showing multiple toasts during consecutive undo/redo actions felt excessive and intrusive.
