### PR TITLE
Fixed #24

### DIFF
--- a/apps/web/src/utils/encoder.ts
+++ b/apps/web/src/utils/encoder.ts
@@ -159,13 +159,12 @@ export function encodeLessonsToSearchParam(lessons: Lesson[]): string {
         }
 
         // Az idővel egybe kerül az id, ha edited
-
         const savedId = lesson.edited ? lesson.id : '';
 
-        const [start_time, end_time] = lesson.time.split('-');
+        const [start_time = "", end_time = ""] = lesson.time.split('-');
 
-        const [start_hour, start_minute] = start_time.split(':').map((str) => str.padStart(2, '0'));
-        const [end_hour, end_minute] = end_time.split(':').map((str) => str.padStart(2, '0'));
+        const [start_hour, start_minute] = start_time === "" ? ["01","00"] : start_time.split(':').map((str) => str.padStart(2, '0'));
+        const [end_hour, end_minute] = start_time === "" ? ["01","00"] : end_time.split(':').map((str) => str.padStart(2, '0'));
 
         parts.push(`${start_hour}${start_minute}${end_hour}${end_minute}${savedId}`);
 


### PR DESCRIPTION
Elvben ez megoldja a #24 problémát. A probléma az volt, hogy vannak olyan órák is, amelyeknek nincs se kezdés, se vége ideje:

<img width="1806" height="125" alt="Image" src="https://github.com/user-attachments/assets/3e1ae544-6a53-4758-b291-10cc60a7d2db" />

Ezek az órák most úgy exportálom, hogy alapértelmezetten hajnali 1-kor kezdődnek és végződnek:

<img width="253" height="166" alt="image" src="https://github.com/user-attachments/assets/f2afb52d-1de4-423c-a0ef-74b8b910b99f" />

Ezek a betöltött órák majd ugyanúgy szerkeszthetőek más időpontra, mint a többi. 

Abban viszont kicsit kevésbé vagyok biztos, hogy ez az alapértelmezett idő a legmegfelelőbb.
