### PR TITLE
Fix course data mapping in Neptun Excel upload

### DIFF
--- a/apps/web/src/Search.tsx
+++ b/apps/web/src/Search.tsx
@@ -101,7 +101,7 @@ const Search: React.FC<SearchProps> = ({ onSubmit, isLoading }: SearchProps) => 
             }
 
             const courses: Course[] = importedData.map((subArray) => {
-                return { courseCode: subArray[0], courseId: subArray[2] };
+                return { courseCode: subArray[3], courseId: subArray[0] };
             });
 
             const formData = {


### PR DESCRIPTION
December 6-a óta más a neptun felület, és ez más exportált kurzusok xlsx-et is eredményez.
<img width="946" height="158" alt="image" src="https://github.com/user-attachments/assets/b66777fa-ec1e-4803-9936-c2d184ea5285" />

Mostmár az új excel formátum szerint működik a beolvasás 